### PR TITLE
use IntoIterator trait in gen_many macros

### DIFF
--- a/src/gen.rs
+++ b/src/gen.rs
@@ -810,7 +810,7 @@ macro_rules! gen_if_else(
 #[macro_export]
 macro_rules! gen_many_ref(
     (($i:expr, $idx:expr), $l:expr, $f:expr) => (
-        $l.iter().fold(
+        $l.into_iter().fold(
             Ok(($i,$idx)),
             |r,ref v| {
                 match r {
@@ -827,9 +827,9 @@ macro_rules! gen_many_ref(
 #[macro_export]
 macro_rules! gen_many(
     (($i:expr, $idx:expr), $l:expr, $f:expr) => (
-        $l.iter().fold(
+        $l.into_iter().fold(
             Ok(($i,$idx)),
-            |r,&v| {
+            |r,v| {
                 match r {
                     Err(e) => Err(e),
                     Ok(x) => { $f(x, v) },


### PR DESCRIPTION
Not all iterables implement an `iter()` method. This PR allows to directly use an Iterator in gen_many and gen_many_ref macros using the IntoIterator trait. Code like `gen_many!(std::iter::repeat(0).take(42), set_be_u8)` is then possible.

This change may break previous usage of gen_many because it is not guaranteed `into_iter()` and `iter()` always behave the same.